### PR TITLE
Include method for proxy support with /etc/profile and disable update

### DIFF
--- a/init.d/codedeploy-agent
+++ b/init.d/codedeploy-agent
@@ -17,6 +17,8 @@
 #                    the deployment artifacts on to this instance.
 ### END INIT INFO
 
+[ -f /etc/profile ] && . /etc/profile
+
 RETVAL=0
 
 prog="codedeploy-agent"
@@ -52,10 +54,10 @@ update() {
 
 case "$1" in
         start)
-                update
                 start
                 ;;
-        start-no-update)
+        start-with-update)
+                update
                 start
                 ;;
         stop)


### PR DESCRIPTION
This adds a mechanism which provides proxy support using /etc/profile.  Adding http_proxy, https_proxy, and no_proxy to /etc/profile.d/proxy.sh enables the codedeploy-agent to connect through proxies if needed.  

This change also disables agent auto update at 'start' by default.